### PR TITLE
Move to a newer ubuntu version

### DIFF
--- a/puppet-lint/Dockerfile
+++ b/puppet-lint/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:14.10
+FROM ubuntu:16.04
 MAINTAINER Dean Wilson
-ENV REFRESHED_AT 2015-02-04-19-45-02
+ENV REFRESHED_AT 2018-04-07-12-05-02
 
 RUN apt-get -yqq update ; apt-get -yqq install ruby ca-certificates
 RUN gem install --no-rdoc --no-ri puppet-lint rake


### PR DESCRIPTION
ubuntu:14.10 is no longer supported so change the base OS for the
image to the new long term supported version.

Thanks to @bschonec for spotting this.